### PR TITLE
Add libgdk-pixbuf2.0-0 for jpeg support with weasyprint

### DIFF
--- a/provisioning/roles/djangoapp/tasks/main.yml
+++ b/provisioning/roles/djangoapp/tasks/main.yml
@@ -99,6 +99,7 @@
     - libavutil-dev
     - libbz2-dev
     - libffi-dev
+    - libgdk-pixbuf2.0-0
     - libghc-text-icu-dev
     - libjpeg-dev
     - libncurses5-dev


### PR DESCRIPTION
When embedding images in pdfs with weasyprint this library is required, otherwise:

> WARNING: Failed to load image at "http://schubertkino.vodclub.online/assets/media/uploads/images/test_schubertkino-horizontal_Sonderfarbe.png.0x100_q85_sharpen.jpg" (Could not load GDK-Pixbuf. PNG and SVG are the only image formats available.)
